### PR TITLE
Add React Native file type to createFormData method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3260,7 +3260,9 @@ export class HttpClient<SecurityDataType = unknown> {
       const propertyContent: any[] = property instanceof Array ? property : [property];
 
       for (const formItem of propertyContent) {
-        const isFileType = formItem instanceof Blob || formItem instanceof File;
+        const isRNFileType = formItem && typeof formItem === "object" && "uri" in formItem && "name" in formItem && "type" in formItem;
+        const isWebFileType = formItem instanceof Blob || formItem instanceof File;
+        const isFileType = isRNFileType || isWebFileType;
         formData.append(key, isFileType ? formItem : this.stringifyFormItem(formItem));
       }
 


### PR DESCRIPTION
The existing `createFormData` method only detects files using Blob and File (which works for web environments) but fails in React Native. React Native does not use Blob or File objects for files; instead, it represents files as plain JavaScript objects with { uri, name, type }.

As a result, file uploads from the React Native app were being treated as regular objects instead of binary files, leading to them to be stringified thus having incorrect form data submission.

To ensure proper file handling across both Web and React Native, this PR updates the createFormData method with a cross-platform file detection.