### PR TITLE
fix: make apply-json-patch-content-type.js idempotent

### DIFF
--- a/scripts/apply-json-patch-content-type.js
+++ b/scripts/apply-json-patch-content-type.js
@@ -26,8 +26,8 @@ try {
 
 // Update PATCH methods to use ContentType.JsonPatch
 content = content.replace(
-	/(method:\s*"PATCH"[\s\S]+?)type:\s*ContentType\.Json/g,
-	(match) => match.replace('ContentType.Json', 'ContentType.JsonPatch')
+	/(method:\s*"PATCH",[\s\S]*?type:\s*)ContentType\.Json\b(?!Patch)/g,
+	'$1ContentType.JsonPatch'
 )
 
 // Ensure JsonPatch is included in the ContentType enum


### PR DESCRIPTION
## Summary
- Fixes a bug in `scripts/apply-json-patch-content-type.js` where repeated runs would corrupt `ContentType.JsonPatch` into `ContentType.JsonPatchPatch`, `ContentType.JsonPatchPatchPatch`, etc.
- The original regex `ContentType\.Json` matched inside `ContentType.JsonPatch`, causing double-replacement on every commit via the pre-commit hook
- Uses a negative lookahead `(?!Patch)` so the replacement only applies when `ContentType.Json` is **not** already followed by `Patch`

## Risk assessment
- Only affects a dev build script (not shipped to consumers)
- No functional change on first run — only prevents corruption on subsequent runs

## Test plan
- [x] Script runs correctly on first execution
- [x] Script is idempotent (3 consecutive runs produce no corruption)
- [x] `grep -c 'ContentType.JsonPatchPatch' src/index.ts` returns 0 after multiple runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)