### PR TITLE
fix: resolve brace-expansion security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "typescript": "^5.5.4"
   },
   "resolutions": {
-    "diff": "^4.0.4"
+    "diff": "^4.0.4",
+    "brace-expansion": "^5.0.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -213,10 +213,10 @@ balanced-match@^4.0.2:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
-brace-expansion@^5.0.2:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.4.tgz#614daaecd0a688f660bbbc909a8748c3d80d4336"
-  integrity sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==
+brace-expansion@^5.0.2, brace-expansion@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
+  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
## Summary
- Added yarn resolution for `brace-expansion@^5.0.5` to fix a **moderate** severity vulnerability (zero-step sequence causes process hang and memory exhaustion)
- `rimraf@6.1.3` is already the latest version but still pulls in `brace-expansion@5.0.4` through transitive dependencies (`glob` → `minimatch` → `brace-expansion`)
- This is a devDependency-only change — **zero impact** on the published SDK or runtime behavior

## Test plan
- [x] `yarn audit` returns 0 vulnerabilities
- [x] `yarn build` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)