### PR TITLE
fix(security): update axios 1.13.6 -> 1.15.0 (critical)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/MortgageAutomationTechnologies/thebigpos-sdk-typescript#readme",
   "dependencies": {
-    "axios": "^1.13.5"
+    "axios": "^1.15.0"
   },
   "devDependencies": {
     "esbuild": "^0.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,14 +199,14 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.13.5:
-  version "1.13.6"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.6.tgz#c3f92da917dc209a15dd29936d20d5089b6b6c98"
-  integrity sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==
+axios@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
+  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
   dependencies:
     follow-redirects "^1.15.11"
     form-data "^4.0.5"
-    proxy-from-env "^1.1.0"
+    proxy-from-env "^2.1.0"
 
 balanced-match@^4.0.2:
   version "4.0.4"
@@ -458,10 +458,10 @@ path-scurry@^2.0.2:
     lru-cache "^11.0.0"
     minipass "^7.1.2"
 
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 rimraf@6.1.3:
   version "6.1.3"


### PR DESCRIPTION
## Security Vulnerability Fix

### Package Updated
| Package | From | To | Severity | Method |
|---|---|---|---|---|
| axios | ^1.13.5 (1.13.6) | ^1.15.0 | critical | direct update |

### Vulnerability Details
- **axios**: NO_PROXY Hostname Normalization Bypass Leads to SSRF (CVE-2025-62718 / GHSA-3p68-rc4w-qgx5)
- **axios**: Unrestricted Cloud Metadata Exfiltration via Header Injection Chain (CVE-2026-40175 / GHSA-fvcv-3m26-pcqx)

Both advisories are resolved in axios `>=1.15.0`.

### Testing
- [x] `yarn audit` shows 0 vulnerabilities
- [x] `yarn build` passes
- [ ] Manual verification by reviewer

### Notes
> Minor version bump (1.13 -> 1.15). Changes in 1.15.0 are limited to the security fixes (header CRLF sanitization and NO_PROXY hostname normalization); no public API changes expected to impact this SDK's usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)