### PR TITLE
fix(security): add follow-redirects ^1.16.0 resolution (moderate)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "resolutions": {
     "diff": "^4.0.4",
-    "brace-expansion": "^5.0.5"
+    "brace-expansion": "^5.0.5",
+    "follow-redirects": "^1.16.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -318,10 +318,10 @@ esbuild@^0.27.0:
     "@esbuild/win32-ia32" "0.27.0"
     "@esbuild/win32-x64" "0.27.0"
 
-follow-redirects@^1.15.11:
-  version "1.15.11"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
-  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+follow-redirects@^1.15.11, follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 form-data@^4.0.5:
   version "4.0.5"


### PR DESCRIPTION
## Security Vulnerability Fix

### Package Updated
| Package | From | To | Severity | Method |
|---|---|---|---|---|
| follow-redirects | 1.15.11 | ^1.16.0 | moderate | yarn resolution |

### Vulnerability Details
- **follow-redirects** (GHSA-r4q5-vmmm-2653): Leaks custom authentication headers (e.g., `X-API-Key`, `X-Auth-Token`) to cross-domain redirect targets. Only `authorization`, `proxy-authorization`, and `cookie` headers were stripped on cross-domain redirects.

### Why a resolution?
While axios declares `follow-redirects: ^1.15.11` (which semver-wise allows 1.16.0), the yarn.lock had pinned it to exactly 1.15.11. A yarn resolution ensures 1.16.0+ is always installed, even on fresh `yarn install`, rather than relying on a manual `yarn upgrade`.

### Testing
- [x] `yarn audit` shows 0 vulnerabilities
- [x] Build passes (`yarn build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)