### PR TITLE
fix(security): update axios ^1.15.0 -> ^1.15.2 (high - prototype pollution & header injection)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/MortgageAutomationTechnologies/thebigpos-sdk-typescript#readme",
   "dependencies": {
-    "axios": "^1.15.0"
+    "axios": "^1.15.2"
   },
   "devDependencies": {
     "esbuild": "^0.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,12 +199,12 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
-  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
+axios@^1.15.2:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
+  integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
   dependencies:
-    follow-redirects "^1.15.11"
+    follow-redirects "^1.16.0"
     form-data "^4.0.5"
     proxy-from-env "^2.1.0"
 
@@ -318,7 +318,7 @@ esbuild@^0.27.0:
     "@esbuild/win32-ia32" "0.27.0"
     "@esbuild/win32-x64" "0.27.0"
 
-follow-redirects@^1.15.11, follow-redirects@^1.16.0:
+follow-redirects@^1.16.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==


### PR DESCRIPTION
## Description

Updates axios from `^1.15.0` to `^1.15.2` to resolve 13 security vulnerabilities (4 high, 8 moderate, 1 low). The most critical issues involve prototype pollution gadgets enabling credential injection, request hijacking, header injection, and a NO_PROXY bypass via loopback subnet (CVE-2025-62718). This is a patch-level update with no breaking changes.

[Monday Link](https://mortgage-automation-technologies.monday.com/boards/5842126081/pulses/11960805720)

## Type of change

- [ ] Bug fix
- [ ] Hot fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Verified `yarn audit` returns 0 vulnerabilities after update
- `yarn build` completes successfully with no errors

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit & integration tests pass locally with my changes
- [ ] I've added test cases to Monday.com for QA (if applicable)