### PR TITLE
fix(security): update brace-expansion ^5.0.5 -> ^5.0.6 (moderate - CVE-2026-45149)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "resolutions": {
     "diff": "^4.0.4",
-    "brace-expansion": "^5.0.5",
+    "brace-expansion": "^5.0.6",
     "follow-redirects": "^1.16.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -213,10 +213,10 @@ balanced-match@^4.0.2:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
-brace-expansion@^5.0.2, brace-expansion@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
-  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
+brace-expansion@^5.0.2, brace-expansion@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
+  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
## Description

Updates the `brace-expansion` resolution from `^5.0.5` to `^5.0.6` to fix a moderate severity DoS vulnerability (CVE-2026-45149) where large numeric ranges bypass the documented `max` protection. This is a transitive dependency via `rimraf > glob > minimatch > brace-expansion` — rimraf is already at the latest version (6.1.3), so a resolution override is required until upstream packages update their constraints.

[Monday Link](https://mortgage-automation-technologies.monday.com/boards/5842126081/pulses/12077622912)

## Type of change

- [x] Bug fix
- [ ] Hot fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran `yarn audit` — confirmed 0 vulnerabilities after the fix
- Ran `yarn build` — passes successfully

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit & integration tests pass locally with my changes
- [ ] I've added test cases to Monday.com for QA (if applicable)