### PR TITLE
fix(deps): move axios to peerDependency to prevent duplicate copies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
     "url": "https://github.com/MortgageAutomationTechnologies/thebigpos-sdk-typescript/issues"
   },
   "homepage": "https://github.com/MortgageAutomationTechnologies/thebigpos-sdk-typescript#readme",
-  "dependencies": {
-    "axios": "^1.16.0"
+  "peerDependencies": {
+    "axios": "^1"
   },
   "devDependencies": {
+    "axios": "^1.16.1",
     "esbuild": "^0.28.1",
     "husky": "^9.1.5",
     "rimraf": "6.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -206,10 +206,10 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.16.0:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.18.0.tgz#8a7f8854af280fcaae063272df2ed9f3837d2398"
-  integrity sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==
+axios@^1.16.1:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.18.1.tgz#d63f9863bcd8938815c86f9e2abd380189d96dfe"
+  integrity sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==
   dependencies:
     follow-redirects "^1.16.0"
     form-data "^4.0.5"


### PR DESCRIPTION
## Description

Moves `axios` from `dependencies` to `peerDependencies` (`^1`) and adds it to `devDependencies`. As a regular dependency, consumers whose own axios version fell outside the SDK's range got a second, nested axios copy in their lockfile — breaking `instanceof AxiosError`, shared interceptors/defaults, and `AxiosRequestConfig` type identity (the SDK passes axios config/types through its public API). A peer dependency guarantees a single shared axios instance owned by the host app.

[Monday Link](https://mortgage-automation-technologies.monday.com/boards/5842126081/pulses/12376318372)

## Type of change

- [x] Bug fix
- [ ] Hot fix
- [ ] New feature
- [ ] Improvement
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Local build (`yarn build` / `tsc`) compiles cleanly with axios resolved via `devDependencies`.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit & integration tests pass locally with my changes
- [ ] I've added test cases to Monday.com for QA (if applicable)